### PR TITLE
fix(src/projects/useCases/project.services.ts):

### DIFF
--- a/src/projects/UseCases/project.services.ts
+++ b/src/projects/UseCases/project.services.ts
@@ -1,6 +1,6 @@
-import { DifficultyLevel, LiveStatus } from "../../shared/types";
-import { ProjectModel } from "../adapters/project.model";
-import { IProject } from "../domain/project.domain";
+import { DifficultyLevel, LiveStatus } from "@/shared/types";
+import { ProjectModel } from "@/adapters/project.model";
+import { IProject } from "@/domain/project.domain";
 
 type ProjectLean = Omit<IProject, "id"> & { _id: unknown; __v?: number };
 

--- a/src/projects/useCases/project.services.ts
+++ b/src/projects/useCases/project.services.ts
@@ -1,6 +1,6 @@
-import { DifficultyLevel, LiveStatus } from "../../shared/types";
-import { ProjectModel } from "../adapters/project.model";
-import { IProject } from "../domain/project.domain";
+import { DifficultyLevel, LiveStatus } from "@/shared/types";
+import { ProjectModel } from "@/adapters/project.model";
+import { IProject } from "@/domain/project.domain";
 
 type ProjectLean = Omit<IProject, "id"> & { _id: unknown; __v?: number };
 


### PR DESCRIPTION
This pull request updates import paths in the project services files to use absolute paths instead of relative ones. This change improves code maintainability and consistency across the codebase.

Refactoring import paths:

* Updated imports in `src/projects/UseCases/project.services.ts` to use absolute paths with the `@` alias for `shared/types`, `adapters/project.model`, and `domain/project.domain`.
* Updated imports in `src/projects/useCases/project.services.ts` to use absolute paths with the `@` alias for `shared/types`, `adapters/project.model`, and `domain/project.domain`.