### PR TITLE
Refactoring /about endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs",
+  "type": "module",
   "bugs": {
     "url": "https://github.com/JDXE22/portfolio-backend/issues"
   },

--- a/src/about/adapters/about.test.ts
+++ b/src/about/adapters/about.test.ts
@@ -46,6 +46,14 @@ describe("About API Tests", () => {
         }),
       ])
     );
+    expect(about.socialLinks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: expect.any(String),
+          iconPublicId: expect.stringMatching(/^https?:\/\//),
+        }),
+      ])
+    );
   });
 });
 

--- a/src/about/adapters/about.test.ts
+++ b/src/about/adapters/about.test.ts
@@ -1,25 +1,30 @@
 import supertest from "supertest";
-import { httpServer } from "@/server";
+import { httpServer } from "../../server";
 
 const api = supertest(httpServer);
 
 describe("About API Tests", () => {
-  it("GET /about should return about information", async () => {
+  it("GET /about should return about information (as array)", async () => {
     const response = await api
       .get("/about")
       .expect(200)
       .expect("Content-Type", /json/);
 
-    expect(response.body).toMatchObject({
+    expect(Array.isArray(response.body)).toBe(true);
+    expect(response.body.length).toBeGreaterThan(0);
+
+    const about = response.body[0];
+
+    expect(about).toMatchObject({
       headline: expect.any(String),
       bio: expect.any(String),
       avatarIconUrl: expect.stringMatching(
         /^https:\/\/res\.cloudinary\.com\/.+$/
       ),
     });
-    expect(response.body.socialLinks).toBeInstanceOf(Array);
 
-    expect(response.body.socialLinks).toEqual(
+    expect(Array.isArray(about.socialLinks)).toBe(true);
+    expect(about.socialLinks).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           name: expect.any(String),
@@ -29,9 +34,9 @@ describe("About API Tests", () => {
         }),
       ])
     );
-    expect(response.body.techStack).toBeInstanceOf(Array);
 
-    expect(response.body.techStack).toEqual(
+    expect(Array.isArray(about.techStack)).toBe(true);
+    expect(about.techStack).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           name: expect.any(String),

--- a/src/about/useCases/getAbout.ts
+++ b/src/about/useCases/getAbout.ts
@@ -3,8 +3,8 @@ import aboutData from "@/about/about.json";
 import { CloudinaryAdapter } from "@/shared/adapters/cloudinary.config";
 import { ICONS } from "@/shared/types";
 
-export async function getAbout(): Promise<AboutInfo> {
-  return {
+export async function getAbout(): Promise<AboutInfo[]> {
+  const normalized: AboutInfo = {
     ...aboutData,
     avatarIconUrl: CloudinaryAdapter.url(aboutData.avatarIconUrl, {
       width: 150,
@@ -23,4 +23,5 @@ export async function getAbout(): Promise<AboutInfo> {
       }),
     })),
   };
+  return [normalized];
 }

--- a/src/about/useCases/getAbout.ts
+++ b/src/about/useCases/getAbout.ts
@@ -22,6 +22,13 @@ export async function getAbout(): Promise<AboutInfo[]> {
         height: 32,
       }),
     })),
+    education: aboutData.education.map((edu) => ({
+      ...edu,
+      iconPublicId: CloudinaryAdapter.url("education", {
+        width: 32,
+        height: 32,
+      }),
+    })),
   };
   return [normalized];
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,17 +12,17 @@ export enum DifficultyLevel {
 }
 
 export interface SocialLink {
-  name: string;
+  name?: string;
   url?: string;
   username?: string;
-  iconPublicId: string
+  iconPublicId: string;
 }
 
 export interface TechStack extends SocialLink {
   iconPublicId: string;
 }
 
-export interface Education {
+export interface Education extends SocialLink {
   degree: string;
   institution: string;
   duration: string;
@@ -46,4 +46,4 @@ export const ICONS: Record<string, string> = {
   CSS3: "css3",
   Tailwind: "tailwindcss",
   Swagger: "swagger",
-}
+};


### PR DESCRIPTION
This pull request introduces several updates to the About API and related data structures, focusing on normalizing the API response to return an array, updating data models for consistency, and adjusting tests accordingly. It also changes the project module type to ES modules.

**API Response Normalization & Data Model Updates:**

* Changed the `getAbout` use case to return an array of `AboutInfo` objects instead of a single object, and normalized the structure of `education` and other fields to include `iconPublicId` URLs. (`src/about/useCases/getAbout.ts`) [[1]](diffhunk://#diff-e169ccaeb6ad7244451e92c858753a1cb58546b573b4c76b7143d43aa243b1ddL6-R7) [[2]](diffhunk://#diff-e169ccaeb6ad7244451e92c858753a1cb58546b573b4c76b7143d43aa243b1ddR25-R33)
* Updated the `SocialLink` and `Education` interfaces to ensure `Education` extends `SocialLink` and made `name` optional in `SocialLink` for greater flexibility. (`src/shared/types.ts`)

**Test Adjustments:**

* Modified the About API tests to expect an array response, updated assertions for `socialLinks` and `techStack`, and added checks for the new structure and URL patterns. (`src/about/adapters/about.test.ts`) [[1]](diffhunk://#diff-aede1a295972db26291acde9b1239ac4c6868a7557544315785a95464f7ea114L2-R27) [[2]](diffhunk://#diff-aede1a295972db26291acde9b1239ac4c6868a7557544315785a95464f7ea114L32-R39) [[3]](diffhunk://#diff-aede1a295972db26291acde9b1239ac4c6868a7557544315785a95464f7ea114R49-R56)

**Project Configuration:**

* Switched the project module type from CommonJS to ES modules for improved compatibility with modern tooling. (`package.json`)