### PR TITLE
refactor(src/projects/domain/project.domain.ts):

### DIFF
--- a/src/projects/domain/project.domain.ts
+++ b/src/projects/domain/project.domain.ts
@@ -13,11 +13,9 @@ export interface ProjectCore {
   reasoning: string;
 }
 
-export interface IProject extends ProjectCore {
-  id: string;
-}
+export interface IProject extends ProjectCore {}
 
-export type CreateProjectDTO = ProjectCore;
+export type CreateProjectDTO = Omit<ProjectCore, "id">;
 
 type MutableProjectFields = Omit<ProjectCore, "reasoning" | "difficultyLevel">;
 


### PR DESCRIPTION
This pull request makes a small but important change to the project type definitions, specifically updating how the `IProject` and `CreateProjectDTO` interfaces are defined. The main improvement is ensuring that the `CreateProjectDTO` type no longer includes the `id` field, which is typically generated by the backend.

Type definition improvements:

* Updated `IProject` to extend `ProjectCore` without redeclaring the `id` property, simplifying the interface.
* Modified `CreateProjectDTO` to use `Omit<ProjectCore, "id">`, ensuring that the `id` field is excluded when creating new projects.