### PR TITLE
Data mapping improvements

### DIFF
--- a/src/about/domain/aboutInfo.ts
+++ b/src/about/domain/aboutInfo.ts
@@ -1,4 +1,4 @@
-import { Education, SocialLink, TechStack } from "../../shared/types";
+import { SocialLink, TechStack } from "@/shared/types";
 
 export interface AboutInfo {
   headline: string;
@@ -7,7 +7,7 @@ export interface AboutInfo {
   skills: string[];
   techStack: TechStack[];
   experience?: { title: string; company: string; duration: string }[];
-  education: Education[];
+  education?: { degree: string; institution: string; duration: string }[];
   certifications?: { title: string; issuer: string; date: string }[];
   socialLinks: SocialLink[];
 }

--- a/src/about/useCases/getAbout.ts
+++ b/src/about/useCases/getAbout.ts
@@ -1,10 +1,9 @@
 import { AboutInfo } from "@/about/domain/aboutInfo";
 import aboutData from "@/about/about.json";
 import { CloudinaryAdapter } from "@/shared/adapters/cloudinary.config";
-import { ICONS } from "@/shared/types";
 
 export async function getAbout(): Promise<AboutInfo[]> {
-  const normalized: AboutInfo = {
+  const normalized = {
     ...aboutData,
     avatarIconUrl: CloudinaryAdapter.url(aboutData.avatarIconUrl, {
       width: 150,
@@ -17,14 +16,7 @@ export async function getAbout(): Promise<AboutInfo[]> {
     })),
     techStack: aboutData.techStack.map((tech) => ({
       ...tech,
-      iconPublicId: CloudinaryAdapter.url(ICONS[tech.name], {
-        width: 32,
-        height: 32,
-      }),
-    })),
-    education: aboutData.education.map((edu) => ({
-      ...edu,
-      iconPublicId: CloudinaryAdapter.url("education", {
+      iconPublicId: CloudinaryAdapter.url(tech.iconPublicId, {
         width: 32,
         height: 32,
       }),


### PR DESCRIPTION
This pull request refactors the `AboutInfo` domain and its usage to simplify type dependencies and update the structure of the `education` and `techStack` fields. The changes remove the reliance on the `Education` type and the `ICONS` constant, and instead use more direct data mapping and type definitions.

**Domain model and type updates:**

* Refactored the `AboutInfo` interface in `aboutInfo.ts` to remove the import of the `Education` type and instead define `education` as an optional array of objects with `degree`, `institution`, and `duration` fields. Also removed unnecessary import of `Education` from `../../shared/types`. [[1]](diffhunk://#diff-a0d48deb587834702b07f37a8e6d8cba9873eef884b373ee066e8c96aa7c1d22L1-R1) [[2]](diffhunk://#diff-a0d48deb587834702b07f37a8e6d8cba9873eef884b373ee066e8c96aa7c1d22L10-R10)

**Data mapping and normalization changes:**

* Updated the `getAbout` use case to remove the dependency on the `ICONS` constant and instead use the `iconPublicId` directly from the `techStack` data. The mapping for `education` was also adjusted to remove the use of a static icon and instead just map the fields as needed. [[1]](diffhunk://#diff-e169ccaeb6ad7244451e92c858753a1cb58546b573b4c76b7143d43aa243b1ddL4-R6) [[2]](diffhunk://#diff-e169ccaeb6ad7244451e92c858753a1cb58546b573b4c76b7143d43aa243b1ddL20-R19)