### PR TITLE
Updated the routes handling errors

### DIFF
--- a/src/projects/domain/project.domain.ts
+++ b/src/projects/domain/project.domain.ts
@@ -12,3 +12,7 @@ export interface ProjectCore {
   difficultyLevel: DifficultyLevel;
   reasoning: string;
 }
+
+type MutableProjectFields = Omit<ProjectCore, "reasoning" | "difficultyLevel">;
+
+export type UpdateProjectDTO = Partial<MutableProjectFields>;

--- a/src/shared/error.handler.ts
+++ b/src/shared/error.handler.ts
@@ -1,13 +1,11 @@
 import { ErrorRequestHandler, NextFunction, Request, Response } from "express";
+import { MulterCode, MulterErrorLike, NamedErrorLike } from "@/shared/types";
 import {
   isDuplicateKey,
   isMulterError,
   isNamedError,
   isObject,
-  MulterCode,
-  MulterErrorLike,
-  NamedErrorLike,
-} from "@/shared/types";
+} from "@/shared/adapters/helpers";
 
 /* ---------- Maps / configuration ---------- */
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -25,13 +25,6 @@ export interface IProject extends ProjectCore {}
 
 export type CreateProjectDTO = Omit<ProjectCore, "id">;
 
-export type MutableProjectFields = Omit<
-  ProjectCore,
-  "reasoning" | "difficultyLevel"
->;
-
-export type UpdateProjectDTO = Partial<MutableProjectFields>;
-
 export interface TechStack extends SocialLink {
   iconPublicId: string;
 }


### PR DESCRIPTION
This pull request refactors how types related to project updates are defined and imported, and cleans up some imports in the error handler. The main focus is on moving the `MutableProjectFields` and `UpdateProjectDTO` type definitions from the shared types file to the project domain file, and correcting import paths in the error handler.

**Type definition refactoring:**

* Moved the `MutableProjectFields` and `UpdateProjectDTO` type definitions from `src/shared/types.ts` to `src/projects/domain/project.domain.ts` to better encapsulate project-specific logic. (`src/projects/domain/project.domain.ts` [[1]](diffhunk://#diff-7b2564cb1ea092474e969230e8f45c58eba63734541f4ce0998545868c4e9a4aR15-R18) `src/shared/types.ts` [[2]](diffhunk://#diff-76b31628824755a528610210e965f349b1c66c2a2ac1e880cf02b4d3b1020a17L28-L34)

**Error handler import cleanup:**

* Updated the import paths in `src/shared/error.handler.ts` to import `MulterCode`, `MulterErrorLike`, and `NamedErrorLike` from `@/shared/types` and helpers from `@/shared/adapters/helpers`, ensuring consistency and removing redundant imports. (`src/shared/error.handler.ts` [src/shared/error.handler.tsR2-R8](diffhunk://#diff-04040333828fe1bf6e627bb57d6d0f3f499d4d43ffef22f522e2f9dfeefe5342R2-R8))