### PR TITLE
Ppdate import paths after moving shared types

### DIFF
--- a/src/projects/adapters/project.model.ts
+++ b/src/projects/adapters/project.model.ts
@@ -1,7 +1,7 @@
 import mongoose, { Schema } from "mongoose";
 import type { HydratedDocument } from "mongoose";
-import { DifficultyLevel, LiveStatus } from "@/shared/types";
-import { IProject } from "@/projects/domain/project.domain";
+import { DifficultyLevel, IProject, LiveStatus } from "@/shared/types";
+
 const projectSchema = new Schema<IProject>({
   title: {
     type: String,

--- a/src/projects/useCases/project.services.ts
+++ b/src/projects/useCases/project.services.ts
@@ -1,6 +1,10 @@
-import { DifficultyLevel, LiveStatus } from "@/shared/types";
+import {
+  CreateProjectDTO,
+  DifficultyLevel,
+  IProject,
+  LiveStatus,
+} from "@/shared/types";
 import { ProjectModel } from "@/projects/adapters/project.model";
-import { CreateProjectDTO, IProject } from "@/projects/domain/project.domain";
 
 type ProjectLean = Omit<IProject, "id"> & { _id: unknown; __v?: number };
 


### PR DESCRIPTION
This pull request updates import statements in the project-related files to ensure all type definitions are consistently imported from the `@/shared/types` module. This helps centralize type management and reduces redundancy across the codebase.

**Type import consolidation:**

* Updated `src/projects/adapters/project.model.ts` to import `IProject` from `@/shared/types` instead of `@/projects/domain/project.domain`, consolidating all type imports from a single source.
* Modified `src/projects/useCases/project.services.ts` to import `CreateProjectDTO` and `IProject` from `@/shared/types` and removed the now-unnecessary import from `@/projects/domain/project.domain`.