### PR TITLE
Add missing property Role in project/model

### DIFF
--- a/src/projects/adapters/project.model.ts
+++ b/src/projects/adapters/project.model.ts
@@ -40,6 +40,10 @@ const projectSchema = new Schema<IProject>({
     enum: Object.values(DifficultyLevel),
     required: true,
   },
+  role: {
+    type: String,
+    required: true,
+  }
 });
 
 type ProjectDoc = HydratedDocument<IProject>;

--- a/src/projects/adapters/project.model.ts
+++ b/src/projects/adapters/project.model.ts
@@ -42,7 +42,6 @@ const projectSchema = new Schema<IProject>({
   },
   role: {
     type: String,
-    required: true,
   }
 });
 

--- a/src/projects/domain/project.domain.ts
+++ b/src/projects/domain/project.domain.ts
@@ -11,6 +11,7 @@ export interface ProjectCore {
   liveStatus: LiveStatus;
   difficultyLevel: DifficultyLevel;
   reasoning: string;
+  role: string;
 }
 
 type MutableProjectFields = Omit<ProjectCore, "reasoning" | "difficultyLevel">;

--- a/src/projects/domain/project.domain.ts
+++ b/src/projects/domain/project.domain.ts
@@ -11,7 +11,7 @@ export interface ProjectCore {
   liveStatus: LiveStatus;
   difficultyLevel: DifficultyLevel;
   reasoning: string;
-  role: string;
+  role?: string;
 }
 
 type MutableProjectFields = Omit<ProjectCore, "reasoning" | "difficultyLevel">;

--- a/src/projects/useCases/project.services.ts
+++ b/src/projects/useCases/project.services.ts
@@ -22,6 +22,7 @@ export const listProjects = async (): Promise<IProject[]> => {
       imgUrl: project.imgUrl,
       repoUrl: project.repoUrl,
       liveUrl: project.liveUrl,
+      role: project.role
     })
   );
 };


### PR DESCRIPTION
This pull request adds a new optional field, `role`, to the project domain model and ensures it is included throughout the project data flow, from the database schema to the service layer and domain interface.

**Model and Schema Updates:**

* Added a `role` field (type: `String`) to the Mongoose schema in `project.model.ts` to store the role associated with each project.
* Updated the `ProjectCore` interface in `project.domain.ts` to include an optional `role` property, ensuring type safety and consistency across the application.

**Service Layer Update:**

* Modified the `listProjects` service in `project.services.ts` to include the `role` property when returning project data.