### PR TITLE
Refactor techStack section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "mongoose": "8.16.3",
         "multer": "2.0.2",
         "nodemailer": "7.0.5",
-        "nodemon": "3.1.10"
+        "nodemon": "3.1.10",
+        "zod": "4.1.11"
       },
       "devDependencies": {
         "@types/cors": "2.8.19",
@@ -7135,6 +7136,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "mongoose": "8.16.3",
     "multer": "2.0.2",
     "nodemailer": "7.0.5",
-    "nodemon": "3.1.10"
+    "nodemon": "3.1.10",
+    "zod": "4.1.11"
   },
   "devDependencies": {
     "@types/cors": "2.8.19",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "jest --watchAll",
     "testEmail": "jest src/contact/adapters/contact.test.ts",
     "testAbout": "jest src/about/adapters/about.test.ts",
-    "testProjects": "jest src/projects/adapters/project.test.ts"
+    "testProjects": "jest src/projects/adapters/project.test.ts",
+    "testStack": "jest src/stack/adapters/stack.router.test.ts"
   },
   "repository": {
     "type": "git",

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import { aboutRouter } from "@/about/adapters/about.router";
 import http from "http";
 import cors from "cors";
 import { corsOptions } from "@/shared/cors.origin";
+import { stackRouterv1 } from "@/stack/adapters/stack.router";
 
 export const server = express();
 
@@ -20,5 +21,7 @@ server.use("/projects", projectRouter);
 server.use("/contact", contactRouter);
 
 server.use("/about", aboutRouter);
+
+server.use("/stack", stackRouterv1)
 
 server.use(errorHandler);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -92,7 +92,7 @@ export interface NamedErrorLike {
 
 // Stack types
 
-export type StackCategory = "frontend" | "backend" | "fullstack" | "database" | "tooling" | "security";
+export type StackCategory = "frontend" | "backend" | "fullstack" | "database" | "tooling" | "security" | "language"
 
 // Education types
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -25,16 +25,6 @@ export interface IProject extends ProjectCore {}
 
 export type CreateProjectDTO = Omit<ProjectCore, "id">;
 
-export interface TechStack extends SocialLink {
-  iconPublicId: string;
-}
-
-export interface Education extends SocialLink {
-  degree: string;
-  institution: string;
-  duration: string;
-}
-
 export interface Certifications {
   title: string;
   issuer: string;
@@ -99,3 +89,39 @@ export interface NamedErrorLike {
   name: string;
   message: string;
 }
+
+// Stack types
+
+export type StackCategory = "frontend" | "backend" | "fullstack" | "database" | "tooling" | "security";
+
+export type Tech = {
+  slug: string;
+  name: string;
+  category: StackCategory;
+  iconPublicId: string;
+}
+
+// Education types
+
+export type Education = {
+  id?: string;
+  title: string;
+  organization: string;
+  description?: string;
+  url?: string;
+}
+
+// Experience types
+
+export type Experience = {
+  id?: string;
+  role: string;
+  company: string;
+  description?: string;
+  startDate: string;
+  endDate?: string;
+  isCurrent?: boolean;
+  url?: string;
+}
+
+

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -94,13 +94,6 @@ export interface NamedErrorLike {
 
 export type StackCategory = "frontend" | "backend" | "fullstack" | "database" | "tooling" | "security";
 
-export type Tech = {
-  slug: string;
-  name: string;
-  category: StackCategory;
-  iconPublicId: string;
-}
-
 // Education types
 
 export type Education = {

--- a/src/stack/adapters/stack.router.test.ts
+++ b/src/stack/adapters/stack.router.test.ts
@@ -1,0 +1,64 @@
+import express, { NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import { stackRouterv1 } from './stack.router';
+import { getStack } from '../useCases/getStack';
+import { StackCategory } from '../../shared/types';
+
+jest.mock('../useCases/getStack', () => ({
+  getStack: jest.fn(),
+}));
+
+const mockedGetStack = getStack as jest.MockedFunction<typeof getStack>;
+
+describe('stackRouterv1', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    app = express();
+    app.use(express.json());
+    // mount the router under /stack so router.get("/") becomes GET /stack
+    app.use('/stack', stackRouterv1);
+    // add error handler so next(error) results in JSON response for assertions
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+      res
+        .status(err.status || 500)
+        .json({ error: err.message || 'Internal Server Error' });
+    });
+  });
+
+  it('responds with 200 and JSON body returned from getStack', async () => {
+    const fakeStack = [
+      {
+        name: 'TypeScript',
+        slug: 'typescript',
+        category: 'language' as StackCategory,
+        iconPublicId: 'https',
+      },
+    ];
+    mockedGetStack.mockReturnValueOnce(fakeStack);
+
+    const res = await request(app)
+      .get('/stack')
+      .expect(200)
+      .expect('Content-Type', /json/);
+
+    expect(res.body).toEqual(fakeStack);
+    expect(mockedGetStack).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards errors from getStack to error handler (returns 500 and error message)', async () => {
+    mockedGetStack.mockImplementationOnce(() => {
+      throw new Error('fetch-failed');
+    });
+
+    const res = await request(app)
+      .get('/stack')
+      .expect(500)
+      .expect('Content-Type', /json/);
+
+    expect(res.body).toEqual({ error: 'fetch-failed' });
+    expect(mockedGetStack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/stack/adapters/stack.router.ts
+++ b/src/stack/adapters/stack.router.ts
@@ -1,0 +1,13 @@
+import { NextFunction, Request, Response, Router } from "express";
+import { getStack } from "../useCases/getStack";
+
+export const stackRouterv1 = Router()
+
+stackRouterv1.get("/", (req: Request, res: Response, next: NextFunction) => {
+    try {
+        const response = getStack()
+        return res.status(200).json(response)
+    } catch (error) {
+        next(error)
+    }
+})

--- a/src/stack/domain/stackInterface.ts
+++ b/src/stack/domain/stackInterface.ts
@@ -1,0 +1,8 @@
+import { StackCategory } from "@/shared/types";
+
+export interface Tech {
+  slug: string;
+  name: string;
+  category: StackCategory;
+  iconPublicId: string;
+}

--- a/src/stack/stack.json
+++ b/src/stack/stack.json
@@ -1,0 +1,111 @@
+[
+  {
+    "name": "Git",
+    "slug": "git",
+    "category": "tooling",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1758577320/git-svgrepo-com_eze0tt.svg"
+  },
+  {
+    "name": "TypeScript",
+    "slug": "typescript",
+    "category": "language",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339630/TypeScript_omjthp.svg"
+  },
+  {
+    "name": "Express",
+    "slug": "express",
+    "category": "backend",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339630/Express_i7qrqa.svg"
+  },
+  {
+    "name": "MongoDB",
+    "slug": "mongodb",
+    "category": "backend",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339628/MongoDB_k6sjb9.svg"
+  },
+  {
+    "name": "Node.js",
+    "slug": "node.js",
+    "category": "backend",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339629/Node.js_wkdyih.svg"
+  },
+  {
+    "name": "PostgreSQL",
+    "slug": "postgresql",
+    "category": "backend",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339630/PostgresSQL_aaelrf.svg"
+  },
+  {
+    "name": "JavaScript",
+    "slug": "javascript",
+    "category": "language",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339632/JavaScript_cuvfc7.svg"
+  },
+  {
+    "name": "SQL",
+    "slug": "sql",
+    "category": "backend",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1758738789/sql-database-sql-azure-svgrepo-com_anmrvb.svg"
+  },
+  {
+    "name": "React",
+    "slug": "react",
+    "category": "frontend",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339631/React_y67zzr.svg"
+  },
+  {
+    "name": "Docker",
+    "slug": "docker",
+    "category": "tooling",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339628/Docker_xjrisg.svg"
+  },
+
+  {
+    "name": "JWT",
+    "slug": "jwt",
+    "category": "security",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1759430269/jwt-3_pgbgor.svg"
+  },
+  {
+    "name": "Auth0",
+    "slug": "auth0",
+    "category": "security",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1759430269/auth0_ssgbil.svg"
+  },
+  {
+    "name": "NestJS",
+    "slug": "nestjs",
+    "category": "backend",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339631/Nest.js_fcfvi5.svg"
+  },
+  {
+    "name": "Stripe",
+    "slug": "stripe",
+    "category": "tooling",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1758577321/stripe-icon_yrriw5.svg"
+  },
+  {
+    "name": "HTML5",
+    "slug": "html5",
+    "category": "frontend",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1758577323/html-5-svgrepo-com_fqv5y7.svg"
+  },
+  {
+    "name": "CSS3",
+    "slug": "css3",
+    "category": "frontend",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1758577321/css-3-svgrepo-com_ewcrjg.svg"
+  },
+  {
+    "name": "Tailwind",
+    "slug": "tailwind",
+    "category": "frontend",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339627/Tailwind_CSS_liqniv.svg"
+  },
+  {
+    "name": "Swagger",
+    "slug": "swagger",
+    "category": "tooling",
+    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339627/Swagger_ztdylg.svg"
+  }
+]

--- a/src/stack/useCases/getStack.ts
+++ b/src/stack/useCases/getStack.ts
@@ -1,0 +1,3 @@
+import { Tech } from "../domain/stackInterface";
+
+export function getStack(): Tech[] {}

--- a/src/stack/useCases/getStack.ts
+++ b/src/stack/useCases/getStack.ts
@@ -1,3 +1,17 @@
-import { Tech } from "../domain/stackInterface";
+import { CloudinaryAdapter } from '@/shared/adapters/cloudinary.config';
+import { Tech } from '@/stack/domain/stackInterface';
+import stack from '@/stack/stack.json';
+import { StackCategory } from '@/shared/types';
 
-export function getStack(): Tech[] {}
+export function getStack(): Tech[] {
+  const stackData = stack.map((tech) => ({
+    ...tech,
+    category: tech.category as StackCategory,
+    iconPublicId: CloudinaryAdapter.url(tech.iconPublicId, {
+      width: 64,
+      height: 64,
+      crop: 'fill',
+    }),
+  }));
+  return stackData;
+}


### PR DESCRIPTION
This pull request introduces a new "stack" feature to the codebase, which provides an API endpoint to retrieve a categorized list of technologies used in the project. It adds all necessary domain types, data, router, and tests for the stack feature, along with some related improvements and dependency updates.

**Stack API feature:**

* Added `stackRouterv1` in `src/stack/adapters/stack.router.ts` to provide a `/stack` endpoint that returns the tech stack as JSON. [[1]](diffhunk://#diff-83b6c0996a576f08e03abb93a59adf0d49dc85dc787cbc4c4801b2d4bd3252bdR1-R13) [[2]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R9) [[3]](diffhunk://#diff-8a8ae07582c9d433ec8c2e5c4310ff8901e604f4965c5b90a49117ad46c47595R25-R26)
* Implemented `getStack` use case in `src/stack/useCases/getStack.ts` to format stack data and generate Cloudinary image URLs for tech icons.
* Defined the `Tech` interface and `StackCategory` type for stack items in `src/stack/domain/stackInterface.ts` and `src/shared/types.ts`. [[1]](diffhunk://#diff-c066ffbf342334b1ee5fb9cd5ce36c4e1473981e70f315e5a4df40ce40b2dbf5R1-R8) [[2]](diffhunk://#diff-76b31628824755a528610210e965f349b1c66c2a2ac1e880cf02b4d3b1020a17R92-R120)
* Added static stack data in `src/stack/stack.json` with categorized technologies and icon URLs.
* Added tests for the stack router in `src/stack/adapters/stack.router.test.ts`, including success and error handling scenarios.

**Other improvements:**

* Added a script for running stack router tests in `package.json` and added the `zod` validation library as a dependency. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L13-R14) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L36-R38)
* Refactored and expanded shared types for education and experience in `src/shared/types.ts`.
* Removed the old `TechStack` and `Education` interfaces from `src/shared/types.ts`, consolidating types for clarity.