### PR TITLE
Change Icon ID

### DIFF
--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,17 +1,17 @@
-import { ProjectCore } from "@/projects/domain/project.domain";
+import { ProjectCore } from '@/projects/domain/project.domain';
 
 // Shared types and enums
 export enum LiveStatus {
-  LIVE = "Live",
-  DOWN = "Down",
-  MAINTENANCE = "Maintenance",
-  DEVELOPMENT = "Development",
+  LIVE = 'Live',
+  DOWN = 'Down',
+  MAINTENANCE = 'Maintenance',
+  DEVELOPMENT = 'Development',
 }
 
 export enum DifficultyLevel {
-  EASY = "Easy",
-  MEDIUM = "Medium",
-  HARD = "Hard",
+  EASY = 'Easy',
+  MEDIUM = 'Medium',
+  HARD = 'Hard',
 }
 
 export interface SocialLink {
@@ -23,7 +23,7 @@ export interface SocialLink {
 
 export interface IProject extends ProjectCore {}
 
-export type CreateProjectDTO = Omit<ProjectCore, "id">;
+export type CreateProjectDTO = Omit<ProjectCore, 'id'>;
 
 export interface Certifications {
   title: string;
@@ -32,44 +32,44 @@ export interface Certifications {
 }
 
 export const ICONS: Record<string, string> = {
-  TypeScript: "typescript",
-  JavaScript: "javascript",
-  React: "react",
-  NodeJS: "nodejs",
-  Express: "express",
-  MongoDB: "mongodb",
-  PostgreSQL: "postgresql",
-  Docker: "docker",
-  SQL: "sql",
-  AWS: "aws",
-  NestJS: "nestjs",
-  Stripe: "stripe",
-  Nodemailer: "nodemailer",
-  HTML5: "html5",
-  CSS3: "css3",
-  Tailwind: "tailwindcss",
-  Swagger: "swagger",
+  TypeScript: 'typescript',
+  JavaScript: 'javascript',
+  React: 'react',
+  NodeJS: 'nodejs',
+  Express: 'express',
+  MongoDB: 'mongodb',
+  PostgreSQL: 'postgresql',
+  Docker: 'docker',
+  SQL: 'sql',
+  AWS: 'aws',
+  NestJS: 'nestjs',
+  Stripe: 'stripe',
+  Nodemailer: 'nodemailer',
+  HTML5: 'html5',
+  CSS3: 'css3',
+  Tailwind: 'tailwindcss',
+  Swagger: 'swagger',
 };
 
 // Error handling types
 
 export type MulterCode =
-  | "LIMIT_FILE_SIZE"
-  | "LIMIT_FILE_COUNT"
-  | "LIMIT_PART_COUNT"
-  | "LIMIT_FIELD_KEY"
-  | "LIMIT_FIELD_VALUE"
-  | "LIMIT_FIELD_COUNT"
-  | "LIMIT_UNEXPECTED_FILE";
+  | 'LIMIT_FILE_SIZE'
+  | 'LIMIT_FILE_COUNT'
+  | 'LIMIT_PART_COUNT'
+  | 'LIMIT_FIELD_KEY'
+  | 'LIMIT_FIELD_VALUE'
+  | 'LIMIT_FIELD_COUNT'
+  | 'LIMIT_UNEXPECTED_FILE';
 
 export const MULTER_ERROR_CODES: ReadonlySet<MulterCode> = new Set([
-  "LIMIT_FILE_SIZE",
-  "LIMIT_FILE_COUNT",
-  "LIMIT_PART_COUNT",
-  "LIMIT_FIELD_KEY",
-  "LIMIT_FIELD_VALUE",
-  "LIMIT_FIELD_COUNT",
-  "LIMIT_UNEXPECTED_FILE",
+  'LIMIT_FILE_SIZE',
+  'LIMIT_FILE_COUNT',
+  'LIMIT_PART_COUNT',
+  'LIMIT_FIELD_KEY',
+  'LIMIT_FIELD_VALUE',
+  'LIMIT_FIELD_COUNT',
+  'LIMIT_UNEXPECTED_FILE',
 ]);
 
 export interface MulterErrorLike {
@@ -79,7 +79,7 @@ export interface MulterErrorLike {
 }
 
 export interface DuplicateKeyErrorLike {
-  name: "MongoServerError";
+  name: 'MongoServerError';
   code: 11000;
   message: string;
   keyValue?: Record<string, unknown>;
@@ -92,7 +92,13 @@ export interface NamedErrorLike {
 
 // Stack types
 
-export type StackCategory = "frontend" | "backend" | "fullstack" | "database" | "tooling" | "security" | "language"
+export type StackCategory =
+  | 'frontend'
+  | 'backend'
+  | 'fullstack'
+  | 'tooling'
+  | 'security'
+  | 'language';
 
 // Education types
 
@@ -102,7 +108,7 @@ export type Education = {
   organization: string;
   description?: string;
   url?: string;
-}
+};
 
 // Experience types
 
@@ -115,6 +121,4 @@ export type Experience = {
   endDate?: string;
   isCurrent?: boolean;
   url?: string;
-}
-
-
+};

--- a/src/stack/adapters/stack.router.test.ts
+++ b/src/stack/adapters/stack.router.test.ts
@@ -1,0 +1,64 @@
+import express, { NextFunction, Request, Response } from 'express';
+import request from 'supertest';
+import { stackRouterv1 } from './stack.router';
+import { getStack } from '../useCases/getStack';
+import { StackCategory } from '../../shared/types';
+
+jest.mock('../useCases/getStack', () => ({
+  getStack: jest.fn(),
+}));
+
+const mockedGetStack = getStack as jest.MockedFunction<typeof getStack>;
+
+describe('stackRouterv1', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    app = express();
+    app.use(express.json());
+    // mount the router under /stack so router.get("/") becomes GET /stack
+    app.use('/stack', stackRouterv1);
+    // add error handler so next(error) results in JSON response for assertions
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
+      res
+        .status(err.status || 500)
+        .json({ error: err.message || 'Internal Server Error' });
+    });
+  });
+
+  it('responds with 200 and JSON body returned from getStack', async () => {
+    const fakeStack = [
+      {
+        name: 'TypeScript',
+        slug: 'typescript',
+        category: 'language' as StackCategory,
+        iconPublicId: 'https',
+      },
+    ];
+    mockedGetStack.mockReturnValueOnce(fakeStack);
+
+    const res = await request(app)
+      .get('/stack')
+      .expect(200)
+      .expect('Content-Type', /json/);
+
+    expect(res.body).toEqual(fakeStack);
+    expect(mockedGetStack).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards errors from getStack to error handler (returns 500 and error message)', async () => {
+    mockedGetStack.mockImplementationOnce(() => {
+      throw new Error('fetch-failed');
+    });
+
+    const res = await request(app)
+      .get('/stack')
+      .expect(500)
+      .expect('Content-Type', /json/);
+
+    expect(res.body).toEqual({ error: 'fetch-failed' });
+    expect(mockedGetStack).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/stack/stack.json
+++ b/src/stack/stack.json
@@ -76,7 +76,7 @@
     "name": "NestJS",
     "slug": "nestjs",
     "category": "backend",
-    "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339631/Nest.js_fcfvi5.svg"
+    "iconPublicId": "Nest.js_fcfvi5"
   },
   {
     "name": "Stripe",


### PR DESCRIPTION
This pull request standardizes the use of single quotes across all string literals in the `src/shared/types.ts` file, improving consistency and readability. Additionally, it updates the `iconPublicId` value for NestJS in the `src/stack/stack.json` file to remove the full Cloudinary URL, now using just the public ID.

Code style and consistency:

* Converted all double-quoted string literals to single quotes in enums, type aliases, interfaces, and constants in `src/shared/types.ts` for improved consistency. [[1]](diffhunk://#diff-76b31628824755a528610210e965f349b1c66c2a2ac1e880cf02b4d3b1020a17L1-R14) [[2]](diffhunk://#diff-76b31628824755a528610210e965f349b1c66c2a2ac1e880cf02b4d3b1020a17L26-R26) [[3]](diffhunk://#diff-76b31628824755a528610210e965f349b1c66c2a2ac1e880cf02b4d3b1020a17L35-R72) [[4]](diffhunk://#diff-76b31628824755a528610210e965f349b1c66c2a2ac1e880cf02b4d3b1020a17L82-R82) [[5]](diffhunk://#diff-76b31628824755a528610210e965f349b1c66c2a2ac1e880cf02b4d3b1020a17L95-R101)
* Updated type definitions to use single quotes and proper formatting for multi-line union types and object types in `src/shared/types.ts`. [[1]](diffhunk://#diff-76b31628824755a528610210e965f349b1c66c2a2ac1e880cf02b4d3b1020a17L105-R111) [[2]](diffhunk://#diff-76b31628824755a528610210e965f349b1c66c2a2ac1e880cf02b4d3b1020a17L118-R124)

Data update:

* Changed the `iconPublicId` for NestJS in `src/stack/stack.json` from a full Cloudinary URL to just the public ID, simplifying asset referencing.