### PR TITLE
Slug property in Projects

### DIFF
--- a/src/projects/adapters/project.model.ts
+++ b/src/projects/adapters/project.model.ts
@@ -1,6 +1,6 @@
-import mongoose, { Schema } from "mongoose";
-import type { HydratedDocument } from "mongoose";
-import { DifficultyLevel, IProject, LiveStatus } from "@/shared/types";
+import mongoose, { Schema } from 'mongoose';
+import type { HydratedDocument } from 'mongoose';
+import { DifficultyLevel, IProject, LiveStatus } from '@/shared/types';
 
 const projectSchema = new Schema<IProject>({
   title: {
@@ -42,17 +42,21 @@ const projectSchema = new Schema<IProject>({
   },
   role: {
     type: String,
-  }
+  },
+  slug: {
+    type: String,
+    unique: true,
+  },
 });
 
 type ProjectDoc = HydratedDocument<IProject>;
 
-projectSchema.virtual("id").get(function (this: ProjectDoc) {
+projectSchema.virtual('id').get(function (this: ProjectDoc) {
   return this._id.toHexString();
 });
-projectSchema.set("toJSON", {
+projectSchema.set('toJSON', {
   virtuals: true,
   versionKey: false,
 });
 
-export const ProjectModel = mongoose.model("Project", projectSchema);
+export const ProjectModel = mongoose.model('Project', projectSchema);

--- a/src/projects/domain/project.domain.ts
+++ b/src/projects/domain/project.domain.ts
@@ -1,10 +1,11 @@
-import { DifficultyLevel, LiveStatus } from "@/shared/types";
+import { DifficultyLevel, LiveStatus } from '@/shared/types';
 
 export interface ProjectCore {
   id: string;
   title: string;
   description: string;
   techStack: string[];
+  slug: string;
   imgUrl?: string;
   repoUrl?: string;
   liveUrl?: string;
@@ -14,6 +15,6 @@ export interface ProjectCore {
   role?: string;
 }
 
-type MutableProjectFields = Omit<ProjectCore, "reasoning" | "difficultyLevel">;
+type MutableProjectFields = Omit<ProjectCore, 'reasoning' | 'difficultyLevel'>;
 
 export type UpdateProjectDTO = Partial<MutableProjectFields>;

--- a/src/projects/useCases/project.services.ts
+++ b/src/projects/useCases/project.services.ts
@@ -3,10 +3,10 @@ import {
   DifficultyLevel,
   IProject,
   LiveStatus,
-} from "@/shared/types";
-import { ProjectModel } from "@/projects/adapters/project.model";
+} from '@/shared/types';
+import { ProjectModel } from '@/projects/adapters/project.model';
 
-type ProjectLean = Omit<IProject, "id"> & { _id: unknown; __v?: number };
+type ProjectLean = Omit<IProject, 'id'> & { _id: unknown; __v?: number };
 
 export const listProjects = async (): Promise<IProject[]> => {
   const projects = (await ProjectModel.find().lean().exec()) as ProjectLean[];
@@ -14,6 +14,7 @@ export const listProjects = async (): Promise<IProject[]> => {
     (project): IProject => ({
       id: String(project._id),
       title: project.title,
+      slug: project.slug,
       description: project.description,
       techStack: project.techStack,
       reasoning: project.reasoning,
@@ -22,7 +23,7 @@ export const listProjects = async (): Promise<IProject[]> => {
       imgUrl: project.imgUrl,
       repoUrl: project.repoUrl,
       liveUrl: project.liveUrl,
-      role: project.role
+      role: project.role,
     })
   );
 };

--- a/src/stack/domain/stackInterface.ts
+++ b/src/stack/domain/stackInterface.ts
@@ -1,7 +1,6 @@
-import { StackCategory } from "@/shared/types";
+import { StackCategory } from '@/shared/types';
 
 export interface Tech {
-  slug: string;
   name: string;
   category: StackCategory;
   iconPublicId: string;

--- a/src/stack/stack.json
+++ b/src/stack/stack.json
@@ -1,110 +1,92 @@
 [
   {
     "name": "Git",
-    "slug": "git",
     "category": "tooling",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1758577320/git-svgrepo-com_eze0tt.svg"
   },
   {
     "name": "TypeScript",
-    "slug": "typescript",
     "category": "language",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339630/TypeScript_omjthp.svg"
   },
   {
     "name": "Express",
-    "slug": "express",
     "category": "backend",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339630/Express_i7qrqa.svg"
   },
   {
     "name": "MongoDB",
-    "slug": "mongodb",
     "category": "backend",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339628/MongoDB_k6sjb9.svg"
   },
   {
     "name": "Node.js",
-    "slug": "node.js",
     "category": "backend",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339629/Node.js_wkdyih.svg"
   },
   {
     "name": "PostgreSQL",
-    "slug": "postgresql",
     "category": "backend",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339630/PostgresSQL_aaelrf.svg"
   },
   {
     "name": "JavaScript",
-    "slug": "javascript",
     "category": "language",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339632/JavaScript_cuvfc7.svg"
   },
   {
     "name": "SQL",
-    "slug": "sql",
     "category": "backend",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1758738789/sql-database-sql-azure-svgrepo-com_anmrvb.svg"
   },
   {
     "name": "React",
-    "slug": "react",
     "category": "frontend",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339631/React_y67zzr.svg"
   },
   {
     "name": "Docker",
-    "slug": "docker",
     "category": "tooling",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339628/Docker_xjrisg.svg"
   },
 
   {
     "name": "JWT",
-    "slug": "jwt",
     "category": "security",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1759430269/jwt-3_pgbgor.svg"
   },
   {
     "name": "Auth0",
-    "slug": "auth0",
     "category": "security",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1759430269/auth0_ssgbil.svg"
   },
   {
     "name": "NestJS",
-    "slug": "nestjs",
     "category": "backend",
     "iconPublicId": "Nest.js_fcfvi5"
   },
   {
     "name": "Stripe",
-    "slug": "stripe",
     "category": "tooling",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1758577321/stripe-icon_yrriw5.svg"
   },
   {
     "name": "HTML5",
-    "slug": "html5",
     "category": "frontend",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1758577323/html-5-svgrepo-com_fqv5y7.svg"
   },
   {
     "name": "CSS3",
-    "slug": "css3",
     "category": "frontend",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1758577321/css-3-svgrepo-com_ewcrjg.svg"
   },
   {
     "name": "Tailwind",
-    "slug": "tailwind",
     "category": "frontend",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339627/Tailwind_CSS_liqniv.svg"
   },
   {
     "name": "Swagger",
-    "slug": "swagger",
     "category": "tooling",
     "iconPublicId": "https://res.cloudinary.com/dqyaxyvxz/image/upload/v1754339627/Swagger_ztdylg.svg"
   }


### PR DESCRIPTION
This pull request introduces a new `slug` field to the `Project` model and updates related interfaces and services to support it. Additionally, it removes the unused `slug` property from the tech stack definitions and domain interfaces, streamlining the stack data structure.

**Project model and service updates:**

* Added a unique `slug` field to the `ProjectModel` schema in `project.model.ts`, and included it in the JSON output and domain interface `ProjectCore`. The `listProjects` service now returns the `slug` for each project. [[1]](diffhunk://#diff-1a7cb1be4197eb1f8a37b9fa404762e712a9a3e1a60256c1e4406a1bda514d3eL45-R62) [[2]](diffhunk://#diff-7b2564cb1ea092474e969230e8f45c58eba63734541f4ce0998545868c4e9a4aL1-R8) [[3]](diffhunk://#diff-7b2564cb1ea092474e969230e8f45c58eba63734541f4ce0998545868c4e9a4aL17-R18) [[4]](diffhunk://#diff-41ba2af4ee82186bc4d0e452990d2d4968d520d9c7ae59b93d4f5bcde567d587L6-R17) [[5]](diffhunk://#diff-41ba2af4ee82186bc4d0e452990d2d4968d520d9c7ae59b93d4f5bcde567d587L25-R26)

**Tech stack clean-up:**

* Removed the unused `slug` property from the `Tech` interface in `stackInterface.ts` and from all tech definitions in `stack.json`, simplifying the stack data structure. [[1]](diffhunk://#diff-c066ffbf342334b1ee5fb9cd5ce36c4e1473981e70f315e5a4df40ce40b2dbf5L1-L4) [[2]](diffhunk://#diff-4ee4a514ed22481c43df855fb21fb2c6c898c37b5256ceab0a6e991edcd395abL4-L107)